### PR TITLE
Add an admin:admin user by default on startup with no users

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -5,6 +5,17 @@ use super::users;
 
 pub fn init() {
     users::init();
+
+    // Bootstrap auth with an admin user if necessary
+    let num_users = users::User::count().unwrap();
+    if num_users == 0 {
+        log::warn!("Bootstrapping auth by creating admin:admin user");
+        log::warn!("Remember to update the username and password of admin:admin user");
+        users::User::create(users::MaybeUser {
+            username: String::from("admin"),
+            password: String::from("admin")
+        }).unwrap();
+    }
 }
 
 pub async fn validator(req: ServiceRequest, credentials: BearerAuth) -> Result<ServiceRequest, Error> {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,5 +1,6 @@
 use actix_web_httpauth::extractors::{AuthenticationError, bearer::{BearerAuth, Config}};
 use actix_web::{Error, dev::ServiceRequest};
+use std::convert::TryInto;
 
 use super::users;
 
@@ -11,10 +12,12 @@ pub fn init() {
     if num_users == 0 {
         log::warn!("Bootstrapping auth by creating admin:admin user");
         log::warn!("Remember to update the username and password of admin:admin user");
-        users::User::create(users::MaybeUser {
+        let user = users::User::create(users::MaybeUser {
             username: String::from("admin"),
             password: String::from("admin")
         }).unwrap();
+        let auth_user: users::AuthUser = user.try_into().unwrap();
+        log::warn!("The initial token for admin:admin is 'Bearer {}'", auth_user.token);
     }
 }
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -17,7 +17,7 @@ pub fn init() {
             password: String::from("admin")
         }).unwrap();
         let auth_user: users::AuthUser = user.try_into().unwrap();
-        log::warn!("The initial token for admin:admin is 'Bearer {}'", auth_user.token);
+        log::warn!("The initial token for admin:admin with id {} is 'Bearer {}'", auth_user.id, auth_user.token);
     }
 }
 

--- a/src/users/model.rs
+++ b/src/users/model.rs
@@ -209,6 +209,11 @@ impl User {
         Ok(res)
     }
 
+    pub fn count() -> Result<i64, CustomError> {
+        let conn = db::connection()?;
+        Ok(users::table.select(diesel::dsl::count_star()).first(&conn)?)
+    }
+
     fn internal_token(username: String, password: String) -> Result<String, CustomError> {
         let db_token = bcrypt(password.as_bytes())?;
         let db_token = base64::encode(db_token.as_slice());


### PR DESCRIPTION
Creates a default user admin:admin. The first thing after deployment should be changing the password.