### PR TITLE
Added shadow delete feature to assets, asset_tags, and contact_events

### DIFF
--- a/migrations/2021-03-10-220926_add_deleted_to_assets/down.sql
+++ b/migrations/2021-03-10-220926_add_deleted_to_assets/down.sql
@@ -1,0 +1,4 @@
+-- This file should undo anything in `up.sql`
+
+ALTER TABLE assets
+DROP COLUMN deleted

--- a/migrations/2021-03-10-220926_add_deleted_to_assets/up.sql
+++ b/migrations/2021-03-10-220926_add_deleted_to_assets/up.sql
@@ -1,0 +1,4 @@
+-- Your SQL goes here
+
+ALTER TABLE assets
+ADD COLUMN deleted BOOLEAN NOT NULL

--- a/migrations/2021-03-10-221228_add_deleted_to_asset_tags/down.sql
+++ b/migrations/2021-03-10-221228_add_deleted_to_asset_tags/down.sql
@@ -1,0 +1,4 @@
+-- This file should undo anything in `up.sql`
+
+ALTER TABLE asset_tags
+DROP COLUMN deleted

--- a/migrations/2021-03-10-221228_add_deleted_to_asset_tags/up.sql
+++ b/migrations/2021-03-10-221228_add_deleted_to_asset_tags/up.sql
@@ -1,0 +1,4 @@
+-- Your SQL goes here
+
+ALTER TABLE asset_tags
+ADD COLUMN deleted BOOLEAN NOT NULL

--- a/migrations/2021-03-10-221355_add_deleted_to_contact_events/down.sql
+++ b/migrations/2021-03-10-221355_add_deleted_to_contact_events/down.sql
@@ -1,0 +1,4 @@
+-- This file should undo anything in `up.sql`
+
+ALTER TABLE contact_events
+DROP COLUMN deleted

--- a/migrations/2021-03-10-221355_add_deleted_to_contact_events/up.sql
+++ b/migrations/2021-03-10-221355_add_deleted_to_contact_events/up.sql
@@ -1,0 +1,4 @@
+-- Your SQL goes here
+
+ALTER TABLE contact_events
+ADD COLUMN deleted BOOLEAN NOT NULL

--- a/src/asset_tags/routes.rs
+++ b/src/asset_tags/routes.rs
@@ -9,6 +9,18 @@ async fn find_all() -> Result<HttpResponse, CustomError> {
     Ok(HttpResponse::Ok().json(asset_tags))
 }
 
+#[get("/asset_tags/all")]
+async fn find_with_deleted() -> Result<HttpResponse, CustomError> {
+    let asset_tags = AssetTag::find_with_deleted()?;
+    Ok(HttpResponse::Ok().json(asset_tags))
+}
+
+#[get("/asset_tags/deleted")]
+async fn find_deleted() -> Result<HttpResponse, CustomError> {
+    let asset_tags = AssetTag::find_deleted()?;
+    Ok(HttpResponse::Ok().json(asset_tags))
+}
+
 #[get("/asset_tags/id/{id}")]
 async fn find_by_id(id: web::Path<i64>) -> Result<HttpResponse, CustomError> {
     let id = id.into_inner();
@@ -71,6 +83,8 @@ async fn delete_by_asset(id: web::Path<i64>) -> Result<HttpResponse, CustomError
 
 pub fn init_routes(comfig: &mut web::ServiceConfig) {
     comfig.service(find_all);
+    comfig.service(find_with_deleted);
+    comfig.service(find_deleted);
     comfig.service(find_by_id);
     comfig.service(find_by_asset);
     comfig.service(find_by_name);

--- a/src/assets/model.rs
+++ b/src/assets/model.rs
@@ -1,7 +1,7 @@
+use crate::asset_tags::AssetTag;
 use crate::db;
 use crate::error_handler::CustomError;
 use crate::schema::assets;
-use crate::asset_tags::AssetTag;
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -12,35 +12,57 @@ use serde::{Deserialize, Serialize};
 #[belongs_to(AssetTag)]
 #[table_name = "assets"]
 pub struct Asset {
-    pub id: i64,    
+    pub id: i64,
     pub asset_tag_id: Option<i64>,
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
+    pub deleted: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, AsChangeset, Insertable)]
 #[table_name = "assets"]
-pub struct MaybeAsset {    
+pub struct MaybeAsset {
     pub asset_tag_id: Option<i64>,
+    pub deleted: bool,
 }
 
 impl Asset {
     pub fn find_all() -> Result<Vec<Self>, CustomError> {
         let conn = db::connection()?;
+        let assets = assets::table
+            .filter(assets::deleted.eq(false))
+            .load::<Asset>(&conn)?;
+        Ok(assets)
+    }
+
+    pub fn find_with_deleted() -> Result<Vec<Self>, CustomError> {
+        let conn = db::connection()?;
         let assets = assets::table.load::<Asset>(&conn)?;
+        Ok(assets)
+    }
+
+    pub fn find_deleted() -> Result<Vec<Self>, CustomError> {
+        let conn = db::connection()?;
+        let assets = assets::table
+            .filter(assets::deleted.eq(true))
+            .load::<Asset>(&conn)?;
         Ok(assets)
     }
 
     pub fn find_by_id(id: i64) -> Result<Self, CustomError> {
         let conn = db::connection()?;
-        let asset = assets::table.filter(assets::id.eq(id)).first(&conn)?;
+        let asset = assets::table
+            .filter(assets::id.eq(id))
+            .filter(assets::deleted.eq(false))
+            .first(&conn)?;
         Ok(asset)
-    }    
+    }
 
     pub fn find_by_asset_tag(id: i64) -> Result<Vec<Self>, CustomError> {
         let conn = db::connection()?;
         let assets = assets::table
             .filter(assets::asset_tag_id.eq(id))
+            .filter(assets::deleted.eq(false))
             .load::<Asset>(&conn)?;
         Ok(assets)
     }
@@ -57,14 +79,19 @@ impl Asset {
         let conn = db::connection()?;
         let asset = diesel::update(assets::table)
             .filter(assets::id.eq(id))
+            .filter(assets::deleted.eq(false))
             .set(asset)
             .get_result(&conn)?;
         Ok(asset)
     }
 
-    pub fn delete(id: i64) -> Result<usize, CustomError> {
+    pub fn delete(id: i64) -> Result<Self, CustomError> {
         let conn = db::connection()?;
-        let res = diesel::delete(assets::table.filter(assets::id.eq(id))).execute(&conn)?;
-        Ok(res)
+        let asset = diesel::update(assets::table)
+            .filter(assets::id.eq(id))
+            .filter(assets::deleted.eq(false))
+            .set(assets::deleted.eq(true))
+            .get_result(&conn)?;
+        Ok(asset)
     }
 }

--- a/src/assets/routes.rs
+++ b/src/assets/routes.rs
@@ -1,11 +1,23 @@
+use crate::assets::{Asset, MaybeAsset};
 use crate::error_handler::CustomError;
-use crate::assets::{MaybeAsset, Asset};
 use actix_web::{delete, get, post, put, web, HttpResponse};
 use log;
 
 #[get("/assets")]
 async fn find_all() -> Result<HttpResponse, CustomError> {
     let assets = Asset::find_all()?;
+    Ok(HttpResponse::Ok().json(assets))
+}
+
+#[get("/assets/all")]
+async fn find_with_deleted() -> Result<HttpResponse, CustomError> {
+    let assets = Asset::find_with_deleted()?;
+    Ok(HttpResponse::Ok().json(assets))
+}
+
+#[get("/assets/deleted")]
+async fn find_deleted() -> Result<HttpResponse, CustomError> {
+    let assets = Asset::find_deleted()?;
     Ok(HttpResponse::Ok().json(assets))
 }
 
@@ -55,7 +67,9 @@ async fn delete(id: web::Path<i64>) -> Result<HttpResponse, CustomError> {
 
 pub fn init_routes(comfig: &mut web::ServiceConfig) {
     comfig.service(find_all);
-    comfig.service(find_by_id);    
+    comfig.service(find_with_deleted);
+    comfig.service(find_deleted);
+    comfig.service(find_by_id);
     comfig.service(find_by_asset_tag);
     comfig.service(create);
     comfig.service(update);

--- a/src/contact_events/routes.rs
+++ b/src/contact_events/routes.rs
@@ -9,6 +9,18 @@ async fn find_all() -> Result<HttpResponse, CustomError> {
     Ok(HttpResponse::Ok().json(contact_events))
 }
 
+#[get("/contact_events/all")]
+async fn find_with_deleted() -> Result<HttpResponse, CustomError> {
+    let contact_events = ContactEvent::find_with_deleted()?;
+    Ok(HttpResponse::Ok().json(contact_events))
+}
+
+#[get("/contact_events/deleted")]
+async fn find_deleted() -> Result<HttpResponse, CustomError> {
+    let contact_events = ContactEvent::find_deleted()?;
+    Ok(HttpResponse::Ok().json(contact_events))
+}
+
 #[get("/contact_events/id/{id}")]
 async fn find_by_id(id: web::Path<i64>) -> Result<HttpResponse, CustomError> {
     let id = id.into_inner();
@@ -71,6 +83,8 @@ async fn delete(id: web::Path<i64>) -> Result<HttpResponse, CustomError> {
 
 pub fn init_routes(comfig: &mut web::ServiceConfig) {
     comfig.service(find_all);
+    comfig.service(find_with_deleted);
+    comfig.service(find_deleted);
     comfig.service(find_by_id);
     comfig.service(find_by_asset_tag);
     comfig.service(find_by_location);

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -27,6 +27,7 @@ table! {
         created_at -> Timestamp,
         updated_at -> Timestamp,
         asset_id -> Int8,
+        deleted -> Bool,
     }
 }
 
@@ -36,6 +37,7 @@ table! {
         asset_tag_id -> Nullable<Int8>,
         created_at -> Timestamp,
         updated_at -> Timestamp,
+        deleted -> Bool,
     }
 }
 
@@ -58,6 +60,7 @@ table! {
         alert_id -> Nullable<Int8>,
         created_at -> Timestamp,
         updated_at -> Timestamp,
+        deleted -> Bool,
     }
 }
 
@@ -104,7 +107,6 @@ table! {
 }
 
 joinable!(alerts -> users (user_id));
-joinable!(assets -> asset_tags (asset_tag_id));
 joinable!(comments -> asset_tags (asset_tag_id));
 joinable!(comments -> users (user_id));
 joinable!(contact_events -> alerts (alert_id));


### PR DESCRIPTION
# Changes
- 3 migrations to add new boolean field to the affected tables
- Changed delete implementation to only toggle the boolean value
- Updated models, routes, and tests to reflect changes
- Added function to delete all asset tags associated with an asset