### PR TITLE
Make asset id on asset tags optional field

### DIFF
--- a/migrations/2021-04-07-210748_asset_id_optional/down.sql
+++ b/migrations/2021-04-07-210748_asset_id_optional/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE asset_tags
+ALTER COLUMN asset_id SET NOT NULL

--- a/migrations/2021-04-07-210748_asset_id_optional/up.sql
+++ b/migrations/2021-04-07-210748_asset_id_optional/up.sql
@@ -1,0 +1,3 @@
+-- Your SQL goes here
+ALTER TABLE asset_tags
+ALTER COLUMN asset_id DROP NOT NULL

--- a/src/asset_tags/model.rs
+++ b/src/asset_tags/model.rs
@@ -18,7 +18,7 @@ pub struct AssetTag {
     pub serial_number: String,
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
-    pub asset_id: i64,
+    pub asset_id: Option<i64>,
     pub deleted: bool,
 }
 
@@ -28,7 +28,7 @@ pub struct MaybeAssetTag {
     pub name: String,
     pub description: Option<String>,
     pub serial_number: String,
-    pub asset_id: i64,
+    pub asset_id: Option<i64>,
     pub deleted: bool,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,7 +128,7 @@ mod tests {
                         name: String::from("initial"),
                         description: Some(String::from("inital")),
                         serial_number: String::from("initial"),
-                        asset_id: INITIAL_ASSET.id,
+                        asset_id: Some(INITIAL_ASSET.id),
                         deleted: false
                     })
                     .expect("Failed to create test asset tag");
@@ -343,7 +343,7 @@ mod tests {
             name: String::from("foo"),
             description: Some(String::from("bar")),
             serial_number: String::from("asdf"),
-            asset_id: INITIAL_ASSET.id,
+            asset_id: Some(INITIAL_ASSET.id),
             deleted: false,
         };
         let payload = serde_json::to_string(&value).expect("Invalid value");
@@ -387,7 +387,7 @@ mod tests {
             name: String::from("foo1"),
             description: Some(String::from("asdflkj")),
             serial_number: String::from("asdf1"),
-            asset_id: INITIAL_ASSET.id,
+            asset_id: Some(INITIAL_ASSET.id),
             deleted: false,
         };
         let payload = serde_json::to_string(&another_value).expect("Invalid value");

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -26,7 +26,7 @@ table! {
         serial_number -> Varchar,
         created_at -> Timestamp,
         updated_at -> Timestamp,
-        asset_id -> Int8,
+        asset_id -> Nullable<Int8>,
         deleted -> Bool,
     }
 }


### PR DESCRIPTION
Basically added a new migration to change the `asset_id` field on `asset_tags` to be optional(nullable)